### PR TITLE
Fix github script overlap validation errors

### DIFF
--- a/.github/workflows/validate-overlaps.yml
+++ b/.github/workflows/validate-overlaps.yml
@@ -54,26 +54,23 @@ jobs:
               const report = JSON.parse(fs.readFileSync('overlap-report.json', 'utf8'));
               
               let comment = `## 📋 Relatório de Validação de Overlaps\n\n`;
-              comment += `**Status:** ${report.metadata.totalIssues === 0 ? '✅ Passou' : '⚠️ Problemas encontrados'}\n\n`;
+              comment += `**Status:** ${report.summary.totalIssues === 0 ? '✅ Passou' : '⚠️ Problemas encontrados'}\n\n`;
               comment += `**Resumo:**\n`;
-              comment += `- Problemas de estrutura: ${report.summary.structure}\n`;
-              comment += `- Palavras-chave suspeitas: ${report.summary.keyword}\n`;
-              comment += `- Conteúdo duplicado: ${report.summary.content}\n`;
-              comment += `- Conteúdo similar: ${report.summary.similarity}\n\n`;
+              comment += `- Total de problemas: ${report.summary.totalIssues}\n`;
+              comment += `- Erros: ${report.summary.errors}\n`;
+              comment += `- Avisos: ${report.summary.warnings}\n`;
+              comment += `- Informações: ${report.summary.info}\n\n`;
               
-              if (report.recommendations.length > 0) {
-                comment += `**💡 Recomendações:**\n`;
-                report.recommendations.forEach(rec => {
-                  comment += `- ${rec.message} (${rec.count} itens)\n`;
-                });
-                comment += `\n`;
-              }
+              comment += `**📊 Estatísticas:**\n`;
+              comment += `- Arquivos escaneados: ${report.stats.filesScanned}\n`;
+              comment += `- Links quebrados: ${report.stats.brokenLinks}\n`;
+              comment += `- Conteúdo duplicado: ${report.stats.duplicateContent}\n`;
+              comment += `- Arquivos ausentes: ${report.stats.missingFiles}\n\n`;
               
               if (report.issues.length > 0) {
                 comment += `**🔍 Problemas Detalhados:**\n`;
                 report.issues.slice(0, 10).forEach(issue => {
                   comment += `- **${issue.type.toUpperCase()}**: ${issue.message}\n`;
-                  comment += `  - Arquivo: \`${issue.path}\`\n`;
                 });
                 
                 if (report.issues.length > 10) {
@@ -93,7 +90,7 @@ jobs:
             } catch (error) {
               console.error('Erro ao processar relatório:', error);
               
-              const errorComment = `## ❌ Erro na Validação de Overlaps\n\n`;
+              let errorComment = `## ❌ Erro na Validação de Overlaps\n\n`;
               errorComment += `Ocorreu um erro durante a validação. Verifique:\n`;
               errorComment += `- Se o arquivo \`sidebars.json\` está válido\n`;
               errorComment += `- Se todas as dependências estão instaladas\n`;

--- a/overlap-report.json
+++ b/overlap-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-07-23T20:25:02.317Z",
+  "timestamp": "2025-07-23T20:33:48.344Z",
   "summary": {
     "totalIssues": 1921,
     "errors": 0,
@@ -18,13447 +18,13447 @@
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:8: Linha longa (151 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:11: Linha longa (165 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:14: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:15: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:16: Linha longa (157 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:17: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:22: Linha longa (216 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:24: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:47: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:50: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:52: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:66: Linha longa (209 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:107: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:374: Linha longa (441 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:556: Linha longa (193 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:586: Linha longa (195 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:741: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:802: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/chatbot-suporte.md:1195: Linha longa (151 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.307Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/classificacao-dados.md:4: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.308Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/classificacao-dados.md:8: Linha longa (154 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.308Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/classificacao-dados.md:10: Linha longa (198 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.308Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/classificacao-dados.md:14: Linha longa (179 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.308Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/classificacao-dados.md:217: Linha longa (200 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.308Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/classificacao-dados.md:218: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.308Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/classificacao-dados.md:239: Linha longa (183 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.308Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/classificacao-dados.md:435: Linha longa (165 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.287Z"
+      "timestamp": "2025-07-23T20:33:48.308Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/advanced-ai/exemplos-casos/ferramentas-ia.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.308Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/ferramentas-ia.md:3: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.308Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/geracao-conteudo.md:8: Linha longa (145 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/geracao-conteudo.md:10: Linha longa (202 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/geracao-conteudo.md:14: Linha longa (169 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/geracao-conteudo.md:167: Linha longa (197 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/geracao-conteudo.md:193: Linha longa (207 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/geracao-conteudo.md:441: Linha longa (157 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/index.md:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/index.md:12: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/index.md:14: Linha longa (244 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/index.md:18: Linha longa (174 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/index.md:30: Linha longa (163 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/index.md:42: Linha longa (181 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/index.md:54: Linha longa (169 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/index.md:66: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/index.md:162: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.288Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:4: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:8: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:10: Linha longa (217 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:14: Linha longa (348 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:18: Linha longa (239 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:32: Linha longa (206 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:39: Linha longa (206 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:41: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:122: Linha longa (199 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:144: Linha longa (192 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:146: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/exemplos-casos/rag-com-arquivos.md:260: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.309Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/index.md:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/index.md:14: Linha longa (152 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/index.md:62: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/advanced-ai/langchain-overview.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/langchain-overview.md:12: Linha longa (400 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/langchain-overview.md:14: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/advanced-ai/nodes-ia/ai-agent.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/ai-agent.md:3: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/index.md:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/index.md:12: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/index.md:16: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/index.md:18: Linha longa (246 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/index.md:20: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/memory-manager.md:10: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/memory-manager.md:12: Linha longa (388 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/memory-manager.md:14: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/openai-chat.md:10: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/openai-chat.md:16: Linha longa (430 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/openai-chat.md:18: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/advanced-ai/nodes-ia/output-parser.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/output-parser.md:13: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/output-parser.md:17: Linha longa (379 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/react-agent.md:10: Linha longa (150 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/react-agent.md:12: Linha longa (388 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/advanced-ai/nodes-ia/sentiment-analysis.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.310Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/sentiment-analysis.md:3: Linha longa (248 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/sentiment-analysis.md:19: Linha longa (176 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/advanced-ai/nodes-ia/sql-agent.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/sql-agent.md:17: Linha longa (401 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/nodes-ia/workflow-tool.md:12: Linha longa (405 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.289Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/tutorial-ai.md:8: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/tutorial-ai.md:11: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/tutorial-ai.md:13: Linha longa (319 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/advanced-ai/tutorial-ai.md:15: Linha longa (403 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/conceitos/autenticacao.md:10: Linha longa (403 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/conceitos/index.md:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/conceitos/index.md:12: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/conceitos/index.md:14: Linha longa (197 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/conceitos/index.md:16: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/conceitos/index.md:23: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/conceitos/paginacao.md:10: Linha longa (366 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/api/ferramentas/index.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/ferramentas/index.md:2: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/ferramentas/index.md:12: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/ferramentas/index.md:14: Linha longa (215 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/ferramentas/index.md:16: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/ferramentas/index.md:20: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/ferramentas/index.md:22: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/ferramentas/index.md:27: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/ferramentas/playground.md:10: Linha longa (378 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/index.md:10: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/index.md:78: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/referencia/index.md:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/referencia/index.md:12: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/referencia/index.md:14: Linha longa (242 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/referencia/index.md:16: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/referencia/index.md:26: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/referencia/index.md:34: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/referencia/referencia-api.md:8: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/api/referencia/referencia-api.md:10: Linha longa (370 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:9: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:14: Linha longa (223 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:17: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:42: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:93: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:129: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:144: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:205: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:220: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:258: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:265: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:274: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/ia-machine-learning.md:283: Linha longa (185 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:12: Linha longa (196 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:15: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:139: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:214: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:229: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:260: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:262: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:268: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:274: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:285: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:321: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.311Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/index.md:330: Linha longa (164 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:9: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:14: Linha longa (189 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:17: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:24: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:42: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:174: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:250: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:298: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:315: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:348: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:355: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:371: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/catalogo/servicos-brasileiros.md:381: Linha longa (208 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.290Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/automacao-iniciantes/index.md:10: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/comunidade/automacao-iniciantes/index.mdx: Link quebrado \"Compartilhe boas práticas\" -> ../../contribuir/esta-documentacao/entendendo-o-projeto/como-contribuir",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/automacao-iniciantes/index.mdx:11: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/automacao-iniciantes/index.mdx:13: Linha longa (237 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/automacao-iniciantes/index.mdx:26: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/automacao-iniciantes/index.mdx:112: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/automacao-iniciantes/index.mdx:122: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/automacao-iniciantes/index.mdx:126: Linha longa (223 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/casos-uso-avancados/index.md:14: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/casos-uso-avancados/index.mdx:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/casos-uso-avancados/index.mdx:59: Linha longa (222 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/como-participar.md:11: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/como-participar.md:13: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/como-participar.md:53: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/como-participar.md:68: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/como-participar.md:70: Linha longa (154 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.312Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/comunidade/estatisticas.mdx: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/estatisticas.mdx:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/estatisticas.mdx:8: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/estatisticas.mdx:42: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/estatisticas.mdx:64: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/estatisticas.mdx:108: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/estatisticas.mdx:132: Linha longa (167 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/estatisticas.mdx:134: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/estatisticas.mdx:174: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/github.mdx:14: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/github.mdx:49: Linha longa (166 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/comunidade/index.mdx: Link quebrado \"Como Criar Seu Primeiro Workflow n8n\" -> ../../primeiros-passos/primeiro-workflow",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.313Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/comunidade/index.mdx: Link quebrado \"Projetos no GitHub\" -> ./github",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.291Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/comunidade/index.mdx: Link quebrado \"Estatísticas da comunidade\" -> ./estatisticas",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/comunidade/index.mdx: Link quebrado \"Histórico no GitHub\" -> ./github",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/index.mdx:9: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/index.mdx:17: Linha longa (261 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/index.mdx:20: Linha longa (192 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/index.mdx:25: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/index.mdx:27: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/index.mdx:28: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/index.mdx:39: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/index.mdx:72: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/index.mdx:87: Linha longa (209 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/videos/index.mdx:4: Linha longa (165 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/videos/index.mdx:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/videos/index.mdx:15: Linha longa (152 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/videos/index.mdx:17: Linha longa (241 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/videos/index.mdx:34: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/videos/index.mdx:47: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/comunidade/videos/index.mdx:97: Linha longa (260 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:12: Linha longa (430 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:14: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:40: Linha longa (264 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:42: Linha longa (294 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:46: Linha longa (384 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:50: Linha longa (181 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:62: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:66: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:68: Linha longa (237 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:74: Linha longa (411 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:78: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:80: Linha longa (387 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/codigo-conduta.md:84: Linha longa (209 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.292Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:8: Linha longa (303 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:10: Linha longa (191 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:14: Linha longa (328 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:24: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:29: Linha longa (294 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:38: Linha longa (292 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:47: Linha longa (296 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:56: Linha longa (298 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:64: Linha longa (306 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:73: Linha longa (280 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:82: Linha longa (296 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:91: Linha longa (282 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:113: Linha longa (298 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:115: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:133: Linha longa (288 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:142: Linha longa (283 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:151: Linha longa (289 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:159: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/codigo-conduta.mdx:168: Linha longa (212 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx: Link quebrado \"Diretrizes Completas\" -> ../padroes-e-estilo/guia-de-estilo",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx: Link quebrado \"Guia de Tradução\" -> ../traducao-e-localizacao/guia-traducao",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx: Link quebrado \"Design System\" -> ../padroes-e-estilo/design-system",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:13: Linha longa (294 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:15: Linha longa (216 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:21: Linha longa (289 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:23: Linha longa (191 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:27: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:28: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:29: Linha longa (160 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:35: Linha longa (288 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:69: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:70: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:77: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:90: Linha longa (288 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:98: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:104: Linha longa (210 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:110: Linha longa (221 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:176: Linha longa (280 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:180: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:212: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:215: Linha longa (174 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:250: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:275: Linha longa (300 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:324: Linha longa (282 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:338: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:350: Linha longa (158 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:355: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:362: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:363: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:368: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:371: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:386: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/como-contribuir.mdx:446: Linha longa (259 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/index.mdx: Link quebrado \"Sobre o Projeto\" -> ./sobre-o-projeto",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/index.mdx: Link quebrado \"Como Contribuir\" -> ./como-contribuir",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/index.mdx: Link quebrado \"Código de Conduta\" -> ./codigo-conduta",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.314Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/sistema-overlaps.md:11: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/sistema-overlaps.md:144: Linha longa (212 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/sistema-overlaps.md:151: Linha longa (151 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/sobre-o-projeto.mdx:12: Linha longa (223 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/sobre-o-projeto.mdx:33: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/01-entendendo-o-projeto/sobre-o-projeto.mdx:94: Linha longa (212 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/exemplos-praticos.mdx: Link quebrado \"Guia de Instalação\" -> ./instalacao",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/exemplos-praticos.mdx: Link quebrado \"Guia de Instalação\" -> ./guia-instalacao",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/exemplos-praticos.mdx: Link quebrado \"guia de contribuição\" -> ./getting-started",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/exemplos-praticos.mdx:11: Linha longa (166 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/exemplos-praticos.mdx:80: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/exemplos-praticos.mdx:89: Linha longa (195 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:8: Linha longa (284 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:10: Linha longa (226 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:14: Linha longa (293 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:38: Linha longa (270 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:83: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:95: Linha longa (285 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:110: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:117: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:138: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:147: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:150: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:153: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:154: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:160: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:170: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:173: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:176: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:182: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:188: Linha longa (300 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/getting-started.mdx:260: Linha longa (153 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/index.md: Link quebrado \"Getting Started\" -> ./getting-started",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/index.md: Link quebrado \"Exemplos Práticos\" -> ./exemplos-praticos",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/index.md: Link quebrado \"Getting Started\" -> ./getting-started",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/index.md: Link quebrado \"Getting Started\" -> ./getting-started",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/index.md: Link quebrado \"Guia de Estilo\" -> ../03-padroes-e-estilo/guia-de-estilo",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/index.md: Link quebrado \"Design System\" -> ../03-padroes-e-estilo/design-system",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/index.md: Link quebrado \"Código de Conduta\" -> ../01-entendendo-o-projeto/codigo-conduta",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/index.md:10: Linha longa (228 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/index.md:63: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/index.md:99: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/contribuir/esta-documentacao/02-primeiros-passos/processo-validacao.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/guia-de-estilo.mdx: Link quebrado \"link\" -> ./exemplo",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/guia-de-estilo.mdx: Link quebrado \"Descrição da imagem\" -> ./caminho/para/imagem.png",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/guia-de-estilo.mdx: Link quebrado \"Guia de Instalação\" -> ./guia-instalacao",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/guia-de-estilo.mdx: Link quebrado \"Configuração de Webhooks\" -> ../integracoes/webhook",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/guia-de-estilo.mdx:36: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/guia-de-estilo.mdx:143: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/guia-de-estilo.mdx:193: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/guia-de-estilo.mdx:208: Linha longa (191 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.293Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/intro.md:7: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:50: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:74: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:99: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:107: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:111: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:115: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:122: Linha longa (147 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:145: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:148: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:165: Linha longa (296 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:173: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/markdown-features.mdx:224: Linha longa (178 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/paleta-cores.mdx:29: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/paleta-cores.mdx:37: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/paleta-cores.mdx:49: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/paleta-cores.mdx:74: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/03-padroes-e-estilo/paleta-cores.mdx:102: Linha longa (231 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.315Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/04-traducao-e-localizacao/guia-traducao.mdx:9: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/04-traducao-e-localizacao/guia-traducao.mdx:13: Linha longa (205 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/04-traducao-e-localizacao/guia-traducao.mdx:16: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/04-traducao-e-localizacao/guia-traducao.mdx:21: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/04-traducao-e-localizacao/guia-traducao.mdx:78: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/04-traducao-e-localizacao/guia-traducao.mdx:209: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/04-traducao-e-localizacao/guia-traducao.mdx:231: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/04-traducao-e-localizacao/guia-traducao.mdx:279: Linha longa (157 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/docusaurus-folder.mdx:9: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/docusaurus-folder.mdx:13: Linha longa (313 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/docusaurus-folder.mdx:21: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/docusaurus-folder.mdx:33: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/docusaurus-folder.mdx:56: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/docusaurus-folder.mdx:136: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/docusaurus-folder.mdx:144: Linha longa (184 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/docusaurus-folder.mdx:149: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/paleta-cores.mdx:188: Linha longa (176 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/validacao-overlaps.md:9: Linha longa (197 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/validacao-overlaps.md:13: Linha longa (200 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/05-recursos-tecnicos/validacao-overlaps.md:313: Linha longa (235 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/06-suporte-e-duvidas/onde-buscar-ajuda.mdx:37: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/06-suporte-e-duvidas/onde-buscar-ajuda.mdx:157: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/06-suporte-e-duvidas/onde-buscar-ajuda.mdx:176: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/06-suporte-e-duvidas/onde-buscar-ajuda.mdx:187: Linha longa (177 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/guidelines.md: Link quebrado \"Guia de Estilo\" -> ./padroes-e-estilo/guia-de-estilo",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/guidelines.md: Link quebrado \"Recursos do Markdown\" -> ./padroes-e-estilo/markdown-features",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/guidelines.md: Link quebrado \"Guia de Estilo\" -> ./padroes-e-estilo/guia-de-estilo",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/guidelines.md: Link quebrado \"Recursos do Markdown\" -> ./padroes-e-estilo/markdown-features",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/guidelines.md: Link quebrado \"Design System\" -> ./padroes-e-estilo/design-system",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/guidelines.md: Link quebrado \"Guia de Tradução\" -> ./traducao-e-localizacao/guia-traducao",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/guidelines.md: Link quebrado \"Código de Conduta\" -> ./entendendo-o-projeto/codigo-conduta",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:9: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:46: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:64: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:82: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:120: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:124: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:128: Linha longa (145 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:134: Linha longa (174 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:140: Linha longa (175 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:162: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/guidelines.md:171: Linha longa (145 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Sobre o Projeto\" -> ./entendendo-o-projeto/sobre-o-projeto",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Como Contribuir\" -> ./entendendo-o-projeto/como-contribuir",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Código de Conduta\" -> ./entendendo-o-projeto/codigo-conduta",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.294Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Getting Started\" -> ./primeiros-passos/getting-started",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Diretrizes para Contribuir\" -> ./padroes-e-estilo/guia-de-estilo",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Recursos do Markdown\" -> ./padroes-e-estilo/markdown-features",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Design System\" -> ./padroes-e-estilo/design-system",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Guia de Tradução\" -> ./traducao-e-localizacao/guia-traducao",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Entendendo o diretório .docusaurus\" -> ./recursos-tecnicos/docusaurus-folder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Paleta de Cores\" -> ./recursos-tecnicos/paleta-cores",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Onde Buscar Ajuda\" -> ./suporte-e-duvidas/onde-buscar-ajuda",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Sobre o Projeto\" -> ./entendendo-o-projeto/sobre-o-projeto",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Getting Started\" -> ./primeiros-passos/getting-started",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/esta-documentacao/index.mdx: Link quebrado \"Diretrizes\" -> ./padroes-e-estilo/guia-de-estilo",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:13: Linha longa (293 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:15: Linha longa (156 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:17: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:21: Linha longa (299 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:50: Linha longa (270 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:55: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:60: Linha longa (297 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:71: Linha longa (279 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:73: Linha longa (224 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/esta-documentacao/index.mdx:79: Linha longa (186 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.md:10: Linha longa (163 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"reportando erros ou sugerindo melhorias\" -> ./esta-documentacao/entendendo-o-projeto/como-contribuir",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"correções simples\" -> ./esta-documentacao/entendendo-o-projeto/como-contribuir",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"<ion-icon name=\"create-outline\" style={{ fontSize: '16px' }}></ion-icon> Escrever Conteúdo\" -> ./esta-documentacao/entendendo-o-projeto/como-contribuir",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"<ion-icon name=\"language-outline\" style={{ fontSize: '16px' }}></ion-icon> Traduzir\" -> ./esta-documentacao/traducao-e-localizacao/guia-traducao",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"<ion-icon name=\"color-palette-outline\" style={{ fontSize: '16px' }}></ion-icon> Design\" -> ./esta-documentacao/padroes-e-estilo/design-system",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"<ion-icon name=\"bug-outline\" style={{ fontSize: '16px' }}></ion-icon> Corrigir Erros\" -> ./esta-documentacao/entendendo-o-projeto/como-contribuir",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"<ion-icon name=\"analytics-outline\" style={{ fontSize: '16px' }}></ion-icon> Estatísticas da Comunidade\" -> ../comunidade/estatisticas",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"<ion-icon name=\"git-network-outline\" style={{ fontSize: '16px' }}></ion-icon> Contribuições no GitHub\" -> ../comunidade/github",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"<ion-icon name=\"star-outline\" style={{ fontSize: '16px' }}></ion-icon> Hall da Fama\" -> ../comunidade/index",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"<ion-icon name=\"ribbon-outline\" style={{ fontSize: '16px' }}></ion-icon> Certificados\" -> ./esta-documentacao/entendendo-o-projeto/sobre-o-projeto",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"<ion-icon name=\"megaphone-outline\" style={{ fontSize: '16px' }}></ion-icon> Divulgação\" -> ../comunidade/index",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.316Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/contribuir/index.mdx: Link quebrado \"<ion-icon name=\"school-outline\" style={{ fontSize: '16px' }}></ion-icon> Aprendizado\" -> ./esta-documentacao/entendendo-o-projeto/sobre-o-projeto",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:4: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:12: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:16: Linha longa (156 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:17: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:22: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:26: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:27: Linha longa (160 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:28: Linha longa (164 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:30: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:34: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:38: Linha longa (191 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:39: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:40: Linha longa (176 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:42: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:44: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:50: Linha longa (230 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:51: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:52: Linha longa (249 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:56: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:58: Linha longa (205 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:59: Linha longa (203 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:60: Linha longa (199 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:61: Linha longa (201 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:63: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:65: Linha longa (181 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:66: Linha longa (179 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:67: Linha longa (192 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:68: Linha longa (178 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:70: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:81: Linha longa (179 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:82: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:84: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:88: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:89: Linha longa (199 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:90: Linha longa (159 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:94: Linha longa (202 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:95: Linha longa (164 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:96: Linha longa (177 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:101: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:104: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:124: Linha longa (147 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/index.mdx:127: Linha longa (156 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/adicionar-casos-uso.md:9: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/adicionar-casos-uso.md:11: Linha longa (206 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/adicionar-casos-uso.md:20: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/adicionar-casos-uso.md:25: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/adicionar-casos-uso.md:43: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/adicionar-casos-uso.md:61: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/adicionar-casos-uso.md:75: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/adicionar-casos-uso.md:91: Linha longa (255 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/afiliados-e-creators.md:9: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/afiliados-e-creators.md:11: Linha longa (211 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/afiliados-e-creators.md:13: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/afiliados-e-creators.md:17: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/afiliados-e-creators.md:21: Linha longa (185 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/afiliados-e-creators.md:40: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/afiliados-e-creators.md:42: Linha longa (254 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/afiliados-e-creators.md:54: Linha longa (225 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:9: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:11: Linha longa (238 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:14: Linha longa (215 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:19: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:27: Linha longa (226 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:31: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:78: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:80: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:98: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:104: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:115: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:129: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-codigo-e-docs.md:152: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-community.md:9: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-community.md:11: Linha longa (211 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-community.md:15: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-community.md:21: Linha longa (203 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-community.md:28: Linha longa (199 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-community.md:33: Linha longa (185 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-community.md:58: Linha longa (154 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-modelos.md:9: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-modelos.md:11: Linha longa (260 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-modelos.md:15: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-modelos.md:18: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-modelos.md:20: Linha longa (179 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-modelos.md:26: Linha longa (197 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-modelos.md:32: Linha longa (162 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-modelos.md:34: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-modelos.md:36: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/contribuir-modelos.md:48: Linha longa (229 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/index.md:9: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/index.md:13: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/index.md:15: Linha longa (285 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/index.md:18: Linha longa (148 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/index.md:27: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/index.md:39: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/index.md:91: Linha longa (347 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/referral-vagas.md:9: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/referral-vagas.md:11: Linha longa (199 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/referral-vagas.md:17: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/referral-vagas.md:25: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/referral-vagas.md:27: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/referral-vagas.md:29: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/referral-vagas.md:31: Linha longa (210 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/referral-vagas.md:35: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/referral-vagas.md:37: Linha longa (176 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/contribuir/n8n-oficial/referral-vagas.md:49: Linha longa (154 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/index.md:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/index.md:17: Linha longa (189 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/index.md:20: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-dois/capitulo-1.md:8: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-dois/capitulo-1.md:10: Linha longa (355 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-dois/capitulo-2.md:8: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-dois/capitulo-2.md:10: Linha longa (327 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-dois/capitulo-3.md:8: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-dois/capitulo-3.md:10: Linha longa (344 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-um/capitulo-1.md:8: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-um/capitulo-1.md:10: Linha longa (350 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-um/capitulo-2.md:8: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-um/capitulo-2.md:10: Linha longa (320 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-um/capitulo-3.md:8: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-um/capitulo-3.md:10: Linha longa (328 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-um/capitulo-4.md:8: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-um/capitulo-4.md:10: Linha longa (327 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-um/capitulo-5.md:8: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-texto/nivel-um/capitulo-5.md:10: Linha longa (360 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-video/curso-avancado.md:8: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-video/curso-avancado.md:10: Linha longa (164 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-video/curso-iniciante.md:8: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-video/curso-iniciante.md:10: Linha longa (150 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.295Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-video/index.md:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-video/index.md:13: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-video/index.md:18: Linha longa (216 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-video/index.md:21: Linha longa (157 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/cursos-em-video/index.md:64: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.317Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/index.md:11: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/index.md:14: Linha longa (200 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/index.md:29: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/index.md:31: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/index.md:57: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/cursos/index.md:59: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:9: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:11: Linha longa (367 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:23: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:32: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:35: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:55: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:68: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:79: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:82: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:118: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:197: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:231: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:261: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:297: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:369: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:379: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:389: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:425: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:565: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:577: Linha longa (160 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/gerenciar-workflows.md:581: Linha longa (150 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/index.md:4: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/index.md:8: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/index.md:12: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/index.md:14: Linha longa (162 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/index.md:19: Linha longa (210 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/index.md:22: Linha longa (190 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/index.md:27: Linha longa (179 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:11: Linha longa (291 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:23: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:30: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:153: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:430: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:437: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:456: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:501: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:560: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:563: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:569: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:570: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:581: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:955: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:967: Linha longa (151 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/gerenciamento/white-labelling.md:971: Linha longa (145 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/configuracao.md:11: Linha longa (223 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/configuracao.md:15: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/configuracao.md:59: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/configuracao.md:115: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/configuracao.md:136: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/configuracao.md:198: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/configuracao.md:214: Linha longa (145 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/implantacao.md:11: Linha longa (242 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/implantacao.md:15: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/implantacao.md:35: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/implantacao.md:62: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/implantacao.md:83: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/implantacao.md:198: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/implantacao.md:216: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/index.md:8: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/index.md:14: Linha longa (157 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/index.md:19: Linha longa (154 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/index.md:22: Linha longa (148 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/implementacao/index.md:27: Linha longa (150 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/index.md:11: Linha longa (183 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/index.md:17: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/index.md:22: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/index.md:25: Linha longa (153 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/index.md:28: Linha longa (158 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/index.md:78: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/index.md:95: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/index.md:8: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/index.md:14: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/index.md:19: Linha longa (161 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/index.md:24: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/index.md:28: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.296Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/prerequisitos.md:11: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/prerequisitos.md:15: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/prerequisitos.md:28: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/prerequisitos.md:50: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/prerequisitos.md:88: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/embed/preparacao/prerequisitos.md:92: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/compliance/lgpd.md:8: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.318Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:11: Linha longa (394 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:23: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:116: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:132: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:162: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:168: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:242: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:288: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:346: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:362: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:371: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:389: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:398: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:430: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:606: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:642: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:654: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/database.md:658: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/index.md:8: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/index.md:14: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/index.md:19: Linha longa (169 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/index.md:22: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/index.md:25: Linha longa (157 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/index.md:28: Linha longa (165 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/index.md:33: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:11: Linha longa (379 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:23: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:149: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:280: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:287: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:295: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:301: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:305: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:306: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:491: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:497: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:541: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:621: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:637: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:640: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:653: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:656: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:662: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:711: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:747: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/queues.md:759: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.297Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:11: Linha longa (387 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:23: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:55: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:76: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:79: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:82: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:92: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:104: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:110: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:111: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:113: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:119: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:158: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:160: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:178: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:271: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:365: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:488: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:493: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:501: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:510: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:520: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:532: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:570: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:578: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:581: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:597: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:600: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:613: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:614: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:630: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:640: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:643: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:650: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:660: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:664: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:665: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:666: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:667: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:668: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:669: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:676: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:712: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/ssl-https.md:728: Linha longa (162 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.319Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:11: Linha longa (406 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:34: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:64: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:67: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:72: Linha longa (164 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:78: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:85: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:90: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:109: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:126: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:134: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:139: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:177: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:188: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:196: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:216: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:400: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:405: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:415: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:503: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/configuracao/variaveis-ambiente.md:532: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:11: Linha longa (404 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:23: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:124: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:131: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:139: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:145: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:149: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:150: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:273: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:447: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:463: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:712: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:720: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:810: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:813: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:816: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:823: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:845: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:851: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:887: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:899: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/clustering.md:903: Linha longa (147 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/index.md:9: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/index.md:15: Linha longa (288 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/index.md:17: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/index.md:90: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/index.md:138: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/index.md:177: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/index.md:205: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/index.md:217: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/index.md:221: Linha longa (156 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:11: Linha longa (404 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:23: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:105: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:191: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:193: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:211: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:320: Linha longa (147 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:328: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:339: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:394: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:411: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:428: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:445: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:460: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:476: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:501: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:520: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:530: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:558: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:590: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:609: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:616: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:644: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:663: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:666: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:680: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:684: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:693: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:702: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:738: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:750: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/load-balancing.md:754: Linha longa (153 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.298Z"
+      "timestamp": "2025-07-23T20:33:48.320Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:9: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:11: Linha longa (368 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:23: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:62: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:66: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:76: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:239: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:246: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:249: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:252: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:255: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:258: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:265: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:271: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:299: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:306: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:394: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:407: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:414: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:424: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:430: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:489: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:497: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:608: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:658: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:691: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:694: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:712: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:719: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:725: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:726: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:731: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:767: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:779: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/escalonamento/performance.md:783: Linha longa (153 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/index.md:10: Linha longa (215 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/index.md:92: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/index.md:137: Linha longa (150 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:10: Linha longa (257 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:28: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:101: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:108: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:119: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:130: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:143: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:151: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:188: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:197: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:206: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:219: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:244: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/aws-brasil.md:393: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/hosting-n8n/instalacao/cloud.md: Link quebrado \"Criar Primeiro Workflow\" -> ../../../primeiros-passos/primeiro-workflow",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/cloud.md:11: Linha longa (153 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/cloud.md:29: Linha longa (194 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/cloud.md:136: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/cloud.md:160: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/cloud.md:315: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/cloud.md:391: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/cloud.md:408: Linha longa (152 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/cloud.md:412: Linha longa (151 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/cloud.md:416: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/hosting-n8n/instalacao/desktop.md: Link quebrado \"Criar Primeiro Workflow\" -> ../../../primeiros-passos/primeiro-workflow",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:11: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:13: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:15: Linha longa (244 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:73: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:99: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:160: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:161: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:162: Linha longa (147 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:163: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:252: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:297: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:300: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:303: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:317: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:318: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:319: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:322: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:328: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:335: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:344: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:347: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:348: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:354: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:359: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:414: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:427: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:444: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/desktop.md:456: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/docker.md:11: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/docker.md:54: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/docker.md:67: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/docker.md:172: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/docker.md:406: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/docker.md:423: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/docker.md:501: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/docker.md:512: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/docker.md:520: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/docker.md:537: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.299Z"
+      "timestamp": "2025-07-23T20:33:48.321Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/hosting-n8n/instalacao/npm.md: Link quebrado \"Criar Primeiro Workflow\" -> ../../../primeiros-passos/primeiro-workflow",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:11: Linha longa (148 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:41: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:131: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:134: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:152: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:159: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:166: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:251: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:262: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:270: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:294: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:297: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:304: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:307: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:310: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:343: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:349: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:355: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:366: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:370: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao/npm.md:374: Linha longa (159 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:9: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:15: Linha longa (200 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:103: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:147: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:181: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:225: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:287: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:292: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:324: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:356: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:384: Linha longa (162 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/instalacao.md:388: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:9: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:11: Linha longa (388 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:23: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:30: Linha longa (150 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:53: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:131: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:159: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:174: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:181: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:192: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:201: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:214: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:222: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:241: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:260: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:266: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:278: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:285: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:298: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:323: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:335: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:347: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:354: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:386: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:429: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:484: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:496: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:532: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:543: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:547: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/autenticacao.md:551: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:11: Linha longa (406 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:23: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:53: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:74: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:81: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:110: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:120: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:147: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:159: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:186: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:204: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:207: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:213: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:252: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:255: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:261: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:301: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:317: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:360: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:370: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:380: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:418: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:426: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:434: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:442: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:464: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:476: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:481: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:492: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:527: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:535: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:566: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:573: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:610: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:654: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:676: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:685: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:723: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:725: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:728: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:731: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:734: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:737: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:740: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:762: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:772: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/backup-recovery.md:808: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.300Z"
+      "timestamp": "2025-07-23T20:33:48.322Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:15: Linha longa (234 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:57: Linha longa (180 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:94: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:163: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:207: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:247: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:269: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:306: Linha longa (162 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:310: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/index.md:314: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:11: Linha longa (386 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:106: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:126: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:130: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:140: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:173: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:248: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:268: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:273: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:280: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:311: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:456: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:527: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:564: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:627: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:663: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:674: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/monitoring.md:682: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/hosting-n8n/seguranca/privacy-security.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/privacy-security.md:3: Linha longa (252 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/privacy-security.md:7: Linha longa (248 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/privacy-security.md:246: Linha longa (203 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/usuarios-permissoes.md:9: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/usuarios-permissoes.md:11: Linha longa (395 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/usuarios-permissoes.md:139: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/usuarios-permissoes.md:247: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/usuarios-permissoes.md:319: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/usuarios-permissoes.md:326: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/usuarios-permissoes.md:439: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/usuarios-permissoes.md:664: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/usuarios-permissoes.md:700: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/hosting-n8n/seguranca/usuarios-permissoes.md:711: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.323Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/app-nodes/communication/gmail.md: Link quebrado \"Gmail Trigger\" -> ../../integracoes/trigger-nodes/app-triggers/gmail-trigger",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/app-nodes/communication/gmail.md: Link quebrado \"Code Node\" -> ../../integracoes/builtin-nodes/core-nodes/code",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/app-nodes/communication/gmail.md: Link quebrado \"Database Nodes\" -> ../../integracoes/builtin-nodes/data-processing",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/app-nodes/communication/gmail.md: Link quebrado \"Error Handling\" -> ../../logica-e-dados/flow-logic/error-handling",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.301Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/gmail.md:10: Linha longa (216 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/gmail.md:487: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/gmail.md:495: Linha longa (367 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/gmail.md:498: Linha longa (329 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/app-nodes/communication/slack.md: Link quebrado \"Webhook Trigger\" -> ../../integracoes/trigger-nodes/event-based/webhook-trigger",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/app-nodes/communication/slack.md: Link quebrado \"HTTP Request\" -> ../../integracoes/builtin-nodes/http-requests/http-request",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/app-nodes/communication/slack.md: Link quebrado \"Code Node\" -> ../../integracoes/builtin-nodes/core-nodes/code",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/app-nodes/communication/slack.md: Link quebrado \"Error Handling\" -> ../../logica-e-dados/flow-logic/error-handling",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/slack.md:10: Linha longa (220 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/slack.md:178: Linha longa (206 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/slack.md:231: Linha longa (160 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/slack.md:265: Linha longa (163 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/slack.md:306: Linha longa (187 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/slack.md:474: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/slack.md:498: Linha longa (367 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/communication/slack.md:501: Linha longa (284 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/ecommerce/index.md:10: Linha longa (399 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/ecommerce/index.md:12: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/index.md:10: Linha longa (207 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/index.md:97: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/index.md:135: Linha longa (145 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/marketing/index.md:10: Linha longa (393 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/marketing/index.md:12: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/productivity/google-sheets.md:10: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/productivity/google-sheets.md:12: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/productivity/google-sheets.md:49: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/app-nodes/productivity/trello.md:10: Linha longa (381 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.324Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/code.md:10: Linha longa (213 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.302Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/expression.md:10: Linha longa (223 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/expression.md:12: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/expression.md:79: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/expression.md:174: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/expression.md:267: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/expression.md:378: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/expression.md:416: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/expression.md:428: Linha longa (153 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/function.md:10: Linha longa (222 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/function.md:12: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/function.md:23: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/function.md:25: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/function.md:409: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/function.md:451: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/function.md:504: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/function.md:516: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/function.md:524: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/index.md:10: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/index.md:16: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/index.md:36: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/index.md:76: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/index.md:96: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/index.md:116: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/integracoes/builtin-nodes/core-nodes/respond-to-webhook.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/builtin-nodes/core-nodes/workflow-trigger.md: Link quebrado \"Subworkflows\" -> ../../logica-e-dados/flow-logic/subworkflows",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/builtin-nodes/core-nodes/workflow-trigger.md: Link quebrado \"Error Handling\" -> ../../logica-e-dados/flow-logic/error-handling",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/builtin-nodes/core-nodes/workflow-trigger.md: Link quebrado \"Execution Order\" -> ../../logica-e-dados/flow-logic/execution-order",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/builtin-nodes/core-nodes/workflow-trigger.md: Link quebrado \"Data Mapping\" -> ../../logica-e-dados/data/data-mapping-avancado",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/workflow-trigger.md:10: Linha longa (237 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/workflow-trigger.md:14: Linha longa (177 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/workflow-trigger.md:187: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/workflow-trigger.md:316: Linha longa (305 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/core-nodes/workflow-trigger.md:321: Linha longa (367 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/aggregate.md:3: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/aggregate.md:10: Linha longa (198 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/index.md:10: Linha longa (244 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/index.md:36: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/index.md:58: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.325Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/set.md:3: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.328Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/set.md:10: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.328Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/set.md:446: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.328Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/split-in-batches.md:10: Linha longa (188 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/split-in-batches.md:12: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/split-in-batches.md:25: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/split-in-batches.md:170: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/split-in-batches.md:212: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/split-in-batches.md:247: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/split-in-batches.md:302: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/split-in-batches.md:323: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/data-processing/split-in-batches.md:355: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.303Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:3: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:10: Linha longa (376 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:12: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:14: Linha longa (164 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:55: Linha longa (200 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:59: Linha longa (184 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:63: Linha longa (226 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:77: Linha longa (200 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:81: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:119: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:164: Linha longa (166 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:176: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:183: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:187: Linha longa (188 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:195: Linha longa (203 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:201: Linha longa (190 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:202: Linha longa (181 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:211: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/http-request.md:214: Linha longa (176 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/index.md:10: Linha longa (234 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/index.md:16: Linha longa (180 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/index.md:37: Linha longa (156 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:12: Linha longa (331 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:31: Linha longa (225 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:32: Linha longa (331 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:49: Linha longa (151 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:54: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:56: Linha longa (214 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:75: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:82: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:87: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:88: Linha longa (174 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:106: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:113: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:117: Linha longa (209 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:126: Linha longa (193 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:134: Linha longa (302 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/http-requests/webhook.md:163: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/index.md:10: Linha longa (199 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/index.md:97: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/index.md:112: Linha longa (152 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/if.md:10: Linha longa (190 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/if.md:474: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/if.md:485: Linha longa (169 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.329Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/index.md:10: Linha longa (233 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/index.md:16: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/index.md:36: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/merge.md:3: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/merge.md:10: Linha longa (203 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.304Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/switch.md:3: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/switch.md:10: Linha longa (191 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/switch.md:551: Linha longa (154 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/builtin-nodes/logic-control/wait.md: Link quebrado \"Error Handling\" -> ../../logica-e-dados/flow-logic/error-handling",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/builtin-nodes/logic-control/wait.md: Link quebrado \"Execution Order\" -> ../../logica-e-dados/flow-logic/execution-order",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/builtin-nodes/logic-control/wait.md: Link quebrado \"Webhook Trigger\" -> ../../integracoes/trigger-nodes/event-based/webhook-trigger",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/integracoes/builtin-nodes/logic-control/wait.md: Link quebrado \"Rate Limiting\" -> ../../logica-e-dados/flow-logic/rate-limiting",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/wait.md:10: Linha longa (216 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/wait.md:14: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/wait.md:306: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/wait.md:437: Linha longa (368 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/logic-control/wait.md:442: Linha longa (367 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/builtin-nodes/utilities/index.md:10: Linha longa (369 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/community-nodes/index.md:8: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/community-nodes/index.md:10: Linha longa (388 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/community-nodes/instalacao.md:8: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/community-nodes/instalacao.md:10: Linha longa (371 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/community-nodes/populares.md:8: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/community-nodes/populares.md:10: Linha longa (383 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/credential-nodes/api-keys.md:8: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/credential-nodes/api-keys.md:10: Linha longa (380 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/credential-nodes/basic-auth.md:8: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/credential-nodes/basic-auth.md:10: Linha longa (385 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/integracoes/credential-nodes/http-request.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.330Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/credential-nodes/index.md:10: Linha longa (202 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/credential-nodes/index.md:14: Linha longa (170 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/credential-nodes/oauth.md:8: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/credential-nodes/oauth.md:10: Linha longa (404 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/integracoes/credential-nodes/webhook.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/criar-nodes/estrutura-node.md:10: Linha longa (404 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/criar-nodes/index.md:7: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/criar-nodes/index.md:9: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/criar-nodes/index.md:25: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/criar-nodes/index.md:41: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/criar-nodes/index.md:49: Linha longa (152 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/criar-nodes/publicar-npm.md:10: Linha longa (375 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.305Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/criar-nodes/tutorial-desenvolvimento.md:8: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/criar-nodes/tutorial-desenvolvimento.md:10: Linha longa (421 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/index.md:10: Linha longa (198 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/index.md:104: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/index.md:142: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/integracoes/templates.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/templates.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/templates.md:14: Linha longa (209 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/app-triggers/index.md:10: Linha longa (363 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/event-based/webhook-trigger.md:10: Linha longa (385 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/index.md:10: Linha longa (191 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/index.md:86: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/index.md:147: Linha longa (152 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.331Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/time-based/manual-trigger.md:3: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/time-based/manual-trigger.md:10: Linha longa (177 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/time-based/manual-trigger.md:374: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/time-based/manual-trigger.md:402: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/time-based/schedule-trigger.md:3: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/trigger-nodes/time-based/schedule-trigger.md:10: Linha longa (234 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/webhooks.md:10: Linha longa (210 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/webhooks.md:14: Linha longa (276 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/webhooks.md:32: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/webhooks.md:41: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes/webhooks.md:58: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/integracoes-br/communication/whatsapp.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/communication/whatsapp.md:3: Linha longa (190 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/integracoes-br/financeiro/compliance-fiscal.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/compliance-fiscal.md:3: Linha longa (151 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/conciliacao-bancaria.md:10: Linha longa (216 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/integracoes-br/financeiro/crm-integration.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.306Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/crm-integration.md:3: Linha longa (186 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/index.md:7: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/nfe-integracao.md:10: Linha longa (210 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.332Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix-avancado.md:11: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix-avancado.md:58: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix-avancado.md:114: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix-avancado.md:153: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix-avancado.md:214: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix-avancado.md:287: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix-avancado.md:342: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix-avancado.md:348: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix-avancado.md:357: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix.md:10: Linha longa (224 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix.md:532: Linha longa (367 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/financeiro/pix.md:535: Linha longa (290 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/governo/cnpj-receita.md:10: Linha longa (219 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/governo/index.md:7: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/index.md:3: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/index.md:10: Linha longa (249 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/localizacao/index.md:7: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/localizacao/viacep.md:10: Linha longa (192 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/localizacao/viacep.md:14: Linha longa (154 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/integracoes-br/marketing/email-automation.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/integracoes-br/marketing/email-automation.md:3: Linha longa (174 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.307Z"
+      "timestamp": "2025-07-23T20:33:48.333Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/intro.md: Link quebrado \"Editar esta página\" -> ./contribuir/esta-documentacao/entendendo-o-projeto/como-contribuir",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/intro.md:11: Linha longa (170 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/intro.md:33: Linha longa (252 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/intro.md:61: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/intro.md:101: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/intro.md:183: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/intro.md:185: Linha longa (274 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/intro.md:195: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/agregacoes-estatisticas.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/agregacoes-estatisticas.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/binary-data.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/binary-data.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/conexoes.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/conexoes.md: Link quebrado \"Execution Order\" -> ../flow-logic/execution-order",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/conexoes.md: Link quebrado \"Error Handling\" -> ../flow-logic/error-handling",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/conexoes.md: Link quebrado \"Subworkflows\" -> ../flow-logic/subworkflows",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/conexoes.md: Link quebrado \"Execution Order\" -> ../flow-logic/execution-order",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/conexoes.md: Link quebrado \"Error Handling\" -> ../flow-logic/error-handling",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/conexoes.md: Link quebrado \"Subworkflows\" -> ../flow-logic/subworkflows",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/conexoes.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/conexoes.md:14: Linha longa (153 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/conexoes.md:16: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/conexoes.md:51: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/conexoes.md:179: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/conexoes.md:305: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/conexoes.md:327: Linha longa (167 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:9: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:11: Linha longa (150 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:15: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:135: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:184: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:246: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:301: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:357: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:403: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:409: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/agregacoes-estatisticas.md:414: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/data/binary-data.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/binary-data.md:3: Linha longa (244 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/binary-data.md:7: Linha longa (217 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/binary-data.md:443: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/data/data-editing.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-editing.md:3: Linha longa (196 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-editing.md:7: Linha longa (165 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/data/data-filtering.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.308Z"
+      "timestamp": "2025-07-23T20:33:48.334Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-filtering.md:3: Linha longa (216 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-filtering.md:7: Linha longa (207 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-filtering.md:310: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-filtering.md:312: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-filtering.md:313: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/data/data-flow-nodes.md: Link quebrado \"Core Nodes\" -> ../integracoes/builtin-nodes/core-nodes/",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-flow-nodes.md:8: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-flow-nodes.md:10: Linha longa (212 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-flow-nodes.md:12: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-flow-nodes.md:16: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-flow-nodes.md:32: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-flow-nodes.md:54: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-flow-nodes.md:123: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-flow-nodes.md:163: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mapping-avancado.md:11: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mapping-avancado.md:15: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mapping-avancado.md:55: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mapping-avancado.md:95: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mapping-avancado.md:138: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mapping-avancado.md:189: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mapping-avancado.md:246: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mapping-avancado.md:298: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mapping-avancado.md:350: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mapping-avancado.md:356: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/data/data-mocking.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mocking.md:3: Linha longa (223 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mocking.md:7: Linha longa (250 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-mocking.md:316: Linha longa (158 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-pinning.md:10: Linha longa (170 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-pinning.md:12: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-pinning.md:14: Linha longa (296 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-pinning.md:85: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-pinning.md:106: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-pinning.md:130: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/data/data-structure.md: Link quebrado \"Core Nodes\" -> ../integracoes/builtin-nodes/core-nodes/",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-structure.md:43: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-structure.md:46: Linha longa (369 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-structure.md:115: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-structure.md:137: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-structure.md:141: Linha longa (259 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-structure.md:145: Linha longa (157 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/data-structure.md:147: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/index.md:10: Linha longa (210 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/index.md:89: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/index.md:133: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/otimizacao-performance.md:7: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/data/schema-preview.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/schema-preview.md:3: Linha longa (196 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/schema-preview.md:239: Linha longa (181 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md: Link quebrado \"HTTP Request\" -> ../integracoes/builtin-nodes/http-requests/http-request",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md: Link quebrado \"Aggregate\" -> ../integracoes/builtin-nodes/data-processing/aggregate",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md: Link quebrado \"Code node\" -> ../integracoes/builtin-nodes/core-nodes/code",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md: Link quebrado \"Set node\" -> ../integracoes/builtin-nodes/data-processing/set",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md: Link quebrado \"Code Node\" -> ../integracoes/builtin-nodes/core-nodes/code",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md: Link quebrado \"Data Processing Nodes\" -> ../integracoes/builtin-nodes/data-processing/",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md:8: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md:10: Linha longa (297 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md:12: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md:18: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md:138: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md:163: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md:185: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md:222: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/data/transformacoes-dados.md:242: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/data-editing.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/data-editing.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/data-filtering.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/data-filtering.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/data-mapping-avancado.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/data-mapping-avancado.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.335Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/data-mocking.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/data-mocking.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/error-handling.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/error-handling.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/execucao.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/execucao.md: Link quebrado \"Execution Order\" -> ../flow-logic/execution-order",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/execucao.md: Link quebrado \"Error Handling\" -> ../flow-logic/error-handling",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/execucao.md: Link quebrado \"Execution Order\" -> ../flow-logic/execution-order",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/execucao.md: Link quebrado \"Error Handling\" -> ../flow-logic/error-handling",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/execucao.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/execucao.md:14: Linha longa (181 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/execucao.md:16: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/execucao.md:32: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/execucao.md:156: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/execucao.md:196: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/execucao.md:267: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/execucao.md:319: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/execucao.md:341: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.309Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/expressoes.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/expressoes.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/expressoes.md:14: Linha longa (209 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/expressoes.md:416: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/debugging.md:10: Linha longa (195 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/debugging.md:12: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/debugging.md:29: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/debugging.md:254: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/debugging.md:276: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/error-handling.md:9: Linha longa (188 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/logica-e-dados/flow-logic/execution-order.md: Link quebrado \"Core Nodes\" -> ../integracoes/builtin-nodes/core-nodes/",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/execution-order.md:10: Linha longa (183 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/execution-order.md:12: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/execution-order.md:66: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/execution-order.md:123: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/execution-order.md:163: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/index.md:10: Linha longa (220 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/index.md:67: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/index.md:71: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/index.md:75: Linha longa (151 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/index.md:112: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/index.md:152: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/looping.md:10: Linha longa (199 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/looping.md:12: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/looping.md:549: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/looping.md:715: Linha longa (367 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/looping.md:718: Linha longa (292 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.336Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/merging.md:10: Linha longa (223 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/merging.md:12: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/merging.md:486: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/merging.md:631: Linha longa (292 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/merging.md:636: Linha longa (367 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.310Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:13: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:15: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:26: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:29: Linha longa (320 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:31: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:36: Linha longa (381 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:136: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:143: Linha longa (220 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:144: Linha longa (224 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:145: Linha longa (148 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:178: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:447: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:721: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:835: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:939: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:946: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:1144: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:1195: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.337Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:1237: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:1305: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:1442: Linha longa (151 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:1447: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:1672: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:1676: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:1728: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/splitting.md:1806: Linha longa (178 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/subworkflows.md:10: Linha longa (255 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/subworkflows.md:12: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/subworkflows.md:432: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/subworkflows.md:588: Linha longa (302 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/subworkflows.md:593: Linha longa (367 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/waiting.md:10: Linha longa (260 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/waiting.md:12: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/waiting.md:352: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/waiting.md:484: Linha longa (367 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/flow-logic/waiting.md:487: Linha longa (363 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.311Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/index.md:10: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/index.md:75: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/index.md:79: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/index.md:83: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/logica-e-dados/index.md:97: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/integracao-apis.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/integracao-apis.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/looping.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/looping.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/merging.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/merging.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/otimizacao-performance.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/otimizacao-performance.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/schema-preview.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/schema-preview.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/splitting.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/splitting.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/subworkflows.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/subworkflows.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/transformacoes-dados.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/transformacoes-dados.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/visualizacao-dados.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/visualizacao-dados.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/logica-e-dados/waiting.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/logica-e-dados/waiting.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-basicos.md:10: Linha longa (154 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-basicos.md:13: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-basicos.md:20: Linha longa (161 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-basicos.md:61: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-basicos.md:113: Linha longa (249 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-basicos.md:285: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-basicos.md:313: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-basicos.md:466: Linha longa (184 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:10: Linha longa (178 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:14: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:34: Linha longa (168 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:75: Linha longa (203 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:127: Linha longa (152 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:163: Linha longa (222 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:167: Linha longa (208 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:202: Linha longa (191 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:214: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:216: Linha longa (218 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conceitos-fundamentais.md:218: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/primeiros-passos/conectar-aplicacoes.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conectar-aplicacoes.md:2: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conectar-aplicacoes.md:14: Linha longa (159 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conectar-aplicacoes.md:16: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conectar-aplicacoes.md:28: Linha longa (241 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conectar-aplicacoes.md:43: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conectar-aplicacoes.md:264: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/conectar-aplicacoes.md:281: Linha longa (203 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/primeiros-passos/faq.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/faq.md:2: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/faq.md:12: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/faq.md:20: Linha longa (267 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/faq.md:33: Linha longa (197 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/faq.md:40: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/faq.md:105: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/faq.md:174: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/faq.md:274: Linha longa (193 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.338Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/primeiros-passos/guia-instalacao.md: Link quebrado \"Self-hosted (Auto-hospedado)\" -> ./instalacao-self-hosted",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:9: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:11: Linha longa (396 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:15: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:17: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:18: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:19: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:20: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:21: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:79: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:84: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:96: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:101: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:127: Linha longa (150 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/guia-instalacao.md:129: Linha longa (144 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/index.md:10: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/index.md:49: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/index.md:53: Linha longa (253 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/index.md:55: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/index.md:70: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/primeiros-passos/instalacao-cloud.md: Link quebrado \"baixar seus workflows\" -> ./instalacao-self-hosted",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:11: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:15: Linha longa (195 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:19: Linha longa (146 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:20: Linha longa (164 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:21: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:22: Linha longa (163 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:23: Linha longa (161 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:26: Linha longa (181 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:32: Linha longa (280 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:47: Linha longa (272 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:135: Linha longa (278 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:138: Linha longa (326 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:156: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:163: Linha longa (168 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:164: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:165: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:169: Linha longa (151 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:180: Linha longa (279 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:197: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:198: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:199: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:200: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:204: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:217: Linha longa (158 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:218: Linha longa (153 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:219: Linha longa (140 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:222: Linha longa (220 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:227: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:236: Linha longa (191 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:252: Linha longa (210 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:257: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:267: Linha longa (216 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:272: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:278: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:279: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:280: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:292: Linha longa (274 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:306: Linha longa (266 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:308: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:309: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:310: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:328: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:348: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:349: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:350: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:351: Linha longa (160 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:354: Linha longa (204 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:359: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:369: Linha longa (196 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:377: Linha longa (286 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:380: Linha longa (368 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:387: Linha longa (201 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:388: Linha longa (186 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:389: Linha longa (163 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:395: Linha longa (226 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:396: Linha longa (185 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:397: Linha longa (188 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:398: Linha longa (178 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:404: Linha longa (231 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:405: Linha longa (180 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:406: Linha longa (182 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:407: Linha longa (203 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:411: Linha longa (213 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:414: Linha longa (193 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:418: Linha longa (327 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:435: Linha longa (272 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:443: Linha longa (272 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:446: Linha longa (333 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:483: Linha longa (282 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:486: Linha longa (335 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:493: Linha longa (164 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:494: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:495: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:496: Linha longa (189 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:502: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:503: Linha longa (148 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:504: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:505: Linha longa (145 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:529: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-cloud.md:542: Linha longa (236 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/primeiros-passos/instalacao-npm.md: Link quebrado \"Self-hosted\" -> ./instalacao-self-hosted",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:12: Linha longa (147 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:42: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:132: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:135: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:153: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:160: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:167: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:252: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:263: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:271: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:295: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:298: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:305: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:308: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:311: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:344: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:350: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:356: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:366: Linha longa (155 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:370: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-npm.md:374: Linha longa (159 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.312Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:13: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:41: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:89: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:211: Linha longa (300 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:269: Linha longa (738 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:273: Linha longa (371 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:311: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:313: Linha longa (323 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:338: Linha longa (376 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:357: Linha longa (357 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:387: Linha longa (365 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:427: Linha longa (332 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:461: Linha longa (301 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:528: Linha longa (241 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:634: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao-self-hosted.mdx:637: Linha longa (335 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/primeiros-passos/instalacao.md: Link quebrado \"FAQ\" -> ../faq",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/primeiros-passos/instalacao.md: Link quebrado \"Self-hosted (Auto-hospedado)\" -> ./instalacao-self-hosted",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:10: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:13: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:15: Linha longa (220 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:18: Linha longa (161 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:25: Linha longa (247 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:30: Linha longa (269 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:64: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:65: Linha longa (161 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:66: Linha longa (161 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:67: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:68: Linha longa (153 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:84: Linha longa (283 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:91: Linha longa (260 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:95: Linha longa (162 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:118: Linha longa (215 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:189: Linha longa (195 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:200: Linha longa (249 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:347: Linha longa (169 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:395: Linha longa (261 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:444: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:445: Linha longa (165 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:446: Linha longa (166 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:447: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:451: Linha longa (163 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:452: Linha longa (186 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/instalacao.md:456: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/primeiros-passos/primeiro-workflow.md:10: Linha longa (160 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/privacidade-seguranca/index.md: Link quebrado \"Resposta a Incidentes\" -> ./incident-response",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/privacidade-seguranca/index.md: Link quebrado \"Configuração de Segurança\" -> ./security-configuration",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/privacidade-seguranca/index.md: Link quebrado \"Criptografia de Dados\" -> ./data-encryption",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/privacidade-seguranca/index.md: Link quebrado \"Controle de Acesso\" -> ./access-control",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/privacidade-seguranca/index.md: Link quebrado \"Auditoria e Logs\" -> ./audit-logs",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.339Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/privacidade-seguranca/index.md: Link quebrado \"Segurança\" -> ./security-configuration",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/index.md:4: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/index.md:8: Linha longa (133 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/index.md:10: Linha longa (258 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/index.md:28: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/index.md:92: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/index.md:108: Linha longa (182 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/privacidade-seguranca/lgpd-compliance.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/lgpd-compliance.md:3: Linha longa (158 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/lgpd-compliance.md:7: Linha longa (213 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/lgpd-compliance.md:674: Linha longa (198 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/privacidade-seguranca/privacy.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/privacy.md:3: Linha longa (199 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/privacy.md:7: Linha longa (200 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/privacy.md:678: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/privacy.md:682: Linha longa (169 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/privacidade-seguranca/security-best-practices.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/privacidade-seguranca/security-best-practices.md: Link quebrado \"tipo\" -> valor",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/security-best-practices.md:3: Linha longa (182 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/security-best-practices.md:7: Linha longa (189 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/privacidade-seguranca/security-best-practices.md:1117: Linha longa (174 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/guias/index.md:7: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.313Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/guias/migration-guide.md:10: Linha longa (350 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/guias/performance-guide.md:10: Linha longa (384 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/guias/troubleshooting.md:7: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/historico/changelog.md:8: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/historico/changelog.md:10: Linha longa (391 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/historico/index.md:9: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/historico/index.md:14: Linha longa (211 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/historico/index.md:85: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/historico/index.md:91: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/historico/index.md:111: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/historico/index.md:140: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.340Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/index.md:9: Linha longa (179 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/index.md:34: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/index.md:54: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/recursos/apis-brasileiras.md:7: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/recursos/apis-brasileiras.md:9: Linha longa (376 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/referencia/recursos/index.md:7: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/usando-n8n/configuracoes.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:9: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:15: Linha longa (137 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:36: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:79: Linha longa (139 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:130: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:161: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:172: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:223: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:274: Linha longa (131 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:299: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:310: Linha longa (158 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:314: Linha longa (143 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/boas-praticas.md:318: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/compartilhamento.md:9: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/compartilhamento.md:11: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/compartilhamento.md:15: Linha longa (142 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/compartilhamento.md:33: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/compartilhamento.md:57: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/compartilhamento.md:106: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/compartilhamento.md:204: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/compartilhamento.md:215: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/compartilhamento.md:219: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/criar-editar.md:11: Linha longa (184 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/credenciais/index.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/index.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/index.md:12: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/index.md:14: Linha longa (178 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/index.md:32: Linha longa (136 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/index.md:47: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.314Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/politicas-seguranca.md:8: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/politicas-seguranca.md:10: Linha longa (194 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/politicas-seguranca.md:12: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/politicas-seguranca.md:105: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/politicas-seguranca.md:317: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/politicas-seguranca.md:908: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/politicas-seguranca.md:926: Linha longa (176 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/treinamento-seguranca.md:10: Linha longa (188 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/treinamento-seguranca.md:12: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/treinamento-seguranca.md:892: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/credenciais/treinamento-seguranca.md:910: Linha longa (182 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/usando-n8n/criar-editar-usuarios.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/execucoes/componentes-execucoes.md:9: Linha longa (164 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/execucoes/componentes-execucoes.md:11: Linha longa (381 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.341Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/execucoes/index.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/execucoes/index.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/execucoes/index.md:14: Linha longa (197 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/usando-n8n/export-import.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/usando-n8n/getting-started/index.md: Link quebrado \"Interface\" -> ./interface/",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/usando-n8n/getting-started/index.md: Link quebrado \"Interface\" -> ./interface/",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/getting-started/index.md:10: Linha longa (152 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/getting-started/index.md:55: Linha longa (241 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/getting-started/index.md:80: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/getting-started/index.md:95: Linha longa (149 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/getting-started/quickstart-rapido.md:9: Linha longa (161 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/getting-started/quickstart-rapido.md:13: Linha longa (177 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/getting-started/workflow-na-pratica.md:9: Linha longa (252 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/getting-started/workflow-na-pratica.md:18: Linha longa (129 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/getting-started/workflow-na-pratica.md:80: Linha longa (205 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/index.md:10: Linha longa (145 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/index.md:27: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/interface/index.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/interface/index.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/interface/index.md:14: Linha longa (162 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/interface/index.md:87: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/interface/index.md:93: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/interface/index.md:119: Linha longa (141 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/interface/navegacao-editor-ui.md:9: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/analisar-logs.md:10: Linha longa (188 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/analisar-logs.md:12: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/analisar-logs.md:516: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/analisar-logs.md:534: Linha longa (188 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/monitoring/index.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/index.md:2: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/index.md:14: Linha longa (174 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:13: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:19: Linha longa (132 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:40: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:80: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:113: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:161: Linha longa (130 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:183: Linha longa (135 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:217: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:223: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/monitoring/visualizar-execucoes.md:228: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/usando-n8n/quickstart-rapido.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/usando-n8n/tags.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/usuarios-permissoes/autenticacao.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/autenticacao.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/autenticacao.md:8: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/autenticacao.md:14: Linha longa (216 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/autenticacao.md:16: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/autenticacao.md:77: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/autenticacao.md:123: Linha longa (128 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/autenticacao.md:316: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/autenticacao.md:334: Linha longa (170 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/criar-editar-usuarios.md:11: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/criar-editar-usuarios.md:15: Linha longa (134 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/criar-editar-usuarios.md:34: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/criar-editar-usuarios.md:66: Linha longa (127 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/criar-editar-usuarios.md:90: Linha longa (138 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/criar-editar-usuarios.md:135: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/criar-editar-usuarios.md:196: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/criar-editar-usuarios.md:218: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.315Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/index.md:9: Linha longa (173 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/index.md:12: Linha longa (125 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/index.md:14: Linha longa (150 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/index.md:50: Linha longa (124 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/usuarios-permissoes/roles-permissoes.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/roles-permissoes.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/roles-permissoes.md:12: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/roles-permissoes.md:14: Linha longa (202 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/roles-permissoes.md:16: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/roles-permissoes.md:164: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/roles-permissoes.md:348: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/roles-permissoes.md:429: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/usuarios-permissoes/roles-permissoes.md:447: Linha longa (182 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.342Z"
     },
     {
       "severity": "info",
       "type": "PLACEHOLDER_PAGE",
       "message": "docs/usando-n8n/workflow-na-pratica.md: Página placeholder",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/workflows/compartilhamento.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/compartilhamento.md:3: Linha longa (207 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/workflows/configuracoes.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/configuracoes.md:3: Linha longa (211 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/workflows/criar-editar.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/criar-editar.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/criar-editar.md:15: Linha longa (196 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/workflows/export-import.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/export-import.md:3: Linha longa (222 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/workflows/historico.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/historico.md:3: Linha longa (221 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/historico.md:7: Linha longa (185 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/historico.md:342: Linha longa (161 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/workflows/index.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/usando-n8n/workflows/index.md: Link quebrado \"Debugging\" -> ./debugging",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "warning",
       "type": "BROKEN_LINK",
       "message": "docs/usando-n8n/workflows/index.md: Link quebrado \"Monitoramento\" -> ./monitoring",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/index.md:2: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/index.md:14: Linha longa (147 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/index.md:39: Linha longa (263 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/index.md:55: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.316Z"
+      "timestamp": "2025-07-23T20:33:48.343Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/workflows/organizar.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/organizar.md:2: Linha longa (172 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/organizar.md:14: Linha longa (183 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/workflows/otimizar.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/otimizar.md:2: Linha longa (171 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/otimizar.md:14: Linha longa (196 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/otimizar.md:16: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/otimizar.md:24: Linha longa (122 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/otimizar.md:81: Linha longa (121 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/otimizar.md:189: Linha longa (126 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/otimizar.md:375: Linha longa (123 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/otimizar.md:393: Linha longa (180 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/workflows/tags.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/tags.md:3: Linha longa (205 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "warning",
       "type": "MISSING_FRONTMATTER",
       "message": "docs/usando-n8n/workflows/workflow-id.md: Frontmatter ausente",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     },
     {
       "severity": "info",
       "type": "LONG_LINE",
       "message": "docs/usando-n8n/workflows/workflow-id.md:3: Linha longa (200 chars)",
       "details": null,
-      "timestamp": "2025-07-23T20:25:02.317Z"
+      "timestamp": "2025-07-23T20:33:48.344Z"
     }
   ]
 }


### PR DESCRIPTION
Fix GitHub Actions workflow script to correctly parse overlap report and avoid runtime errors.

The original script expected a different JSON structure for the `overlap-report.json` (e.g., `report.metadata.totalIssues` and `report.recommendations`) and attempted to reassign a `const` variable. This PR updates the script to match the actual report structure (`report.summary.totalIssues`, `report.stats`) and corrects the variable declaration, ensuring the workflow runs successfully and generates accurate PR comments.

---

[Open in Web](https://www.cursor.com/agents?id=bc-cacae95a-3f5b-4630-8642-65a028923132) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cacae95a-3f5b-4630-8642-65a028923132)